### PR TITLE
Fix theme styles and persistence

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -235,12 +235,14 @@ body.dark-theme nav {
 }
 
 body.dark-theme .work-item {
-    border-color: neonpurple;
+    /* Highlight work items in dark mode with a vibrant purple border */
+    border: 0.125rem solid #9d00ff;
 }
 
 /* Gradient Button Styling */
 #themeToggle {
-    background: linear-gradient(90deg, neonpurple, orange); /* Replace neonpurple with your exact color */
+    /* Use a valid neon purple color for the gradient */
+    background: linear-gradient(90deg, #9d00ff, orange);
     border: none;
     border-radius: 25px;
     color: white;
@@ -255,8 +257,8 @@ body.dark-theme .work-item {
 }
 
 #themeToggle:hover {
-    background: linear-gradient(90deg, orange, neonpurple); /* The gradient direction is reversed on hover */
-    box-shadow: 0 7px 20px rgba(neonpurple, 0.4); /* Give a glow effect using the neonpurple color */
+    background: linear-gradient(90deg, orange, #9d00ff); /* The gradient direction is reversed on hover */
+    box-shadow: 0 7px 20px rgba(157, 0, 255, 0.4); /* Give a glow effect using the neon purple color */
 }
 
 #themeToggle:active {

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,10 +1,13 @@
+// Smooth scrolling for internal anchor links if the target exists
 document.querySelectorAll('a[href^="#"]').forEach(anchor => {
     anchor.addEventListener('click', function (e) {
-        e.preventDefault();
-
-        document.querySelector(this.getAttribute('href')).scrollIntoView({
-            behavior: 'smooth'
-        });
+        const target = document.querySelector(this.getAttribute('href'));
+        if (target) {
+            e.preventDefault();
+            target.scrollIntoView({
+                behavior: 'smooth'
+            });
+        }
     });
 });
 
@@ -38,11 +41,20 @@ document.querySelectorAll('.work-item img').forEach(img => {
     });
 });
 
+// Theme toggling with preference stored in localStorage
 const themeToggle = document.getElementById('themeToggle');
+if (themeToggle) {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+        document.body.classList.add('dark-theme');
+    }
 
-themeToggle.addEventListener('click', function() {
-    document.body.classList.toggle('dark-theme');
-});
+    themeToggle.addEventListener('click', function() {
+        document.body.classList.toggle('dark-theme');
+        const isDark = document.body.classList.contains('dark-theme');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+}
 
 document.addEventListener("DOMContentLoaded", function() {
     var buttons = document.querySelectorAll('button[data-href]');


### PR DESCRIPTION
## Summary
- replace invalid `neonpurple` color references with valid hex code
- add dark-mode border styling for work items
- persist theme preference and guard smooth scrolling anchors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f32086548332b3a9dcbe43b0d47e